### PR TITLE
Newest litex fixes

### DIFF
--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -296,6 +296,16 @@ button{}: Miscellaneous.Button @ cas {}
     return result
 
 
+def get_clock_frequency():
+    """
+    Returns:
+        int: system clock frequency
+    """
+    # in different LiteX versions this property
+    # has different names
+    return constants['config_clock_frequency' if 'config_clock_frequency' in constants else 'system_clock_frequency']['value']
+
+
 def generate_repl():
     """ Generates platform definition.
 
@@ -316,7 +326,7 @@ def generate_repl():
             'model': 'Timers.LiteX_Timer',
             'properties': {
                 'frequency':
-                    lambda: constants['system_clock_frequency']['value']
+                    lambda: get_clock_frequency()
             }
         },
         'ethmac': {
@@ -333,7 +343,7 @@ def generate_repl():
             'model': 'Timers.LiteX_CPUTimer',
             'properties': {
                 'frequency':
-                    lambda: constants['system_clock_frequency']['value']
+                    lambda: get_clock_frequency()
             },
             'interrupts': {
                 # IRQ #100 in Renode's VexRiscv model is mapped to Machine Timer Interrupt

--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -13,9 +13,9 @@ import csv
 import zlib
 import argparse
 
-# this memory region is defined and handled
-# directly by LiteEth model in Renode
-non_generated_mem_regions = ['ethmac', 'spiflash']
+# those memory regions are handled in a special way
+# and should not be generated automatically
+non_generated_mem_regions = ['ethmac', 'spiflash', 'csr']
 
 mem_regions = {}
 peripherals = {}


### PR DESCRIPTION
This PR contains fixes required to run `generate-renode-scripts.py` on the newest LiteX master.