### PR TITLE
Adapt to GDB API changes in Renode

### DIFF
--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -463,7 +463,7 @@ def generate_resc(repl_file, host_tap_interface=None, bios_binary=None, firmware
 using sysbus
 mach create "litex-{}"
 machine LoadPlatformDescription @{}
-cpu StartGdbServer 10001
+machine StartGdbServer 10001
 showAnalyzer sysbus.uart
 showAnalyzer sysbus.uart Antmicro.Renode.Analyzers.LoggingUartAnalyzer
 """.format(cpu_type, repl_file)


### PR DESCRIPTION
Commit dc30e76 in Renode changed API of managing GDB
to support multi-core platforms. From this point
all oprations are executed at machine's level instead of CPU.