### PR TITLE
Skip generation of linker regions

### DIFF
--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -361,8 +361,9 @@ def generate_repl():
 
 
 def filter_memory_regions(raw_regions, alignment=None):
-    """ Filters memory regions skipping those from `non_generated_mem_regions`
-        list and verifying if they have proper size and do not overlap.
+    """ Filters memory regions skipping those of linker type
+        and those from `non_generated_mem_regions` list
+        and verifying if they have proper size and do not overlap.
 
         Args:
             raw_regions (list): list of memory regions parsed from
@@ -377,6 +378,14 @@ def filter_memory_regions(raw_regions, alignment=None):
 
     raw_regions.sort(key=lambda x: x['address'])
     for r in raw_regions:
+        if 'linker' in r['type']:
+            print('Skipping linker region: {}'.format(r['name']))
+            continue
+
+        if r['name'] in non_generated_mem_regions:
+            print('Skipping pre-defined memory region: {}'.format(r['name']))
+            continue
+
         if alignment is not None and r['size'] % alignment != 0:
             print('Error: `{}` memory region size ({}) is not aligned to {}'.format(r['name'], hex(r['size']), hex(alignment)))
             sys.exit(1)
@@ -384,10 +393,6 @@ def filter_memory_regions(raw_regions, alignment=None):
         if previous_region is not None and (previous_region['address'] + previous_region['size']) > (r['address'] + r['size']):
             print("Error: detected overlaping memory regions: `{}` and `{}`".format(r['name'], previous_region['name']))
             sys.exit(1)
-
-        if r['name'] in non_generated_mem_regions:
-            print('Skipping pre-defined memory region: {}'.format(r['name']))
-            continue
 
         previous_region = r
         yield r

--- a/litex/configuration.py
+++ b/litex/configuration.py
@@ -69,7 +69,8 @@ class Configuration(object):
             elif _type == 'memory_region':
                 self.mem_regions[_name] = {'name': _name,
                                            'address': int(_val, 0),
-                                           'size': int(_val2, 0)}
+                                           'size': int(_val2, 0),
+                                           'type': _val3}
             else:
                 print('Skipping unexpected CSV entry: {} {}'.format(_type, _name))
 


### PR DESCRIPTION
LiteX configuration might contain definition of memory
subregions needed by linker scripts.

This commit adds parsing of memory region type and
filtering out linker memory regions to avoid generation
of overlapping memory fragments in the platform definition
for Renode.