### PR TITLE
Add d[value]=0 placeholder for the register value.

### DIFF
--- a/generate-mocserver-json.py
+++ b/generate-mocserver-json.py
@@ -22,6 +22,9 @@ def mk_obj():
         for key in path[:-1]:
             d = d[key]
         d[path[-1]] = value
+        # add a placeholder for where the register's value
+        # (other keys are metadata about this value)
+        d[path[-1]]['value'] = 0
 
     the_dict = make_dict()
     for register in configuration.registers:


### PR DESCRIPTION
Original plan was to swap out all the dict of address, type, rw.... metadata for the value, but it may come in handy later, so this adds a value property next to it.