### PR TITLE
Do not automatically start the simulation

### DIFF
--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -453,7 +453,6 @@ connector Connect host.tap switch
         result += 'sysbus WriteDoubleWord {} {}\n'.format(hex(flash_boot_address + 4), hex(crc32))
         result += 'sysbus LoadBinary @{} {}\n'.format(firmware_binary, hex(flash_boot_address + 8))
 
-    result += 'start'
     return result
 
 


### PR DESCRIPTION
Not starting the simulation at the end of
the generated script allows to execute
additional instructions.