### PR TITLE
Generate etherbone bridge

### DIFF
--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Copyright (c) 2019 Antmicro
+Copyright (c) 2019 - 2020 Antmicro
 
 Renode platform definition (repl) and script (resc) generator for LiteX SoC.
 


### PR DESCRIPTION
This adds an option to use etherbone bridge for selected peripherals allowing to generate a HW co-simulated setup.