### PR TITLE
Add I2C support

### DIFF
--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -374,6 +374,10 @@ peripherals_handlers = {
     'ctrl': {
         'handler': generate_peripheral,
         'model': 'Miscellaneous.LiteX_SoC_Controller'
+    },
+    'i2c0': {
+        'handler': generate_peripheral,
+        'model': 'I2C.LiteX_I2C'
     }
 }
 

--- a/generate-zephyr-dts.py
+++ b/generate-zephyr-dts.py
@@ -61,6 +61,20 @@ def ethmac_handler(peripheral, **kw):
     return result
 
 
+def i2c_handler(peripheral, **kw):
+    result = """
+&{} {{
+    reg = <{} {} {} {}>;
+}};
+""".format(kw['reference'],
+           hex(peripheral['address']),
+           hex(kw['size']),
+           hex(peripheral['address'] + kw['size']),
+           hex(kw['size']))
+
+    return result
+
+
 def peripheral_handler(peripheral, **kw):
     result = """
 &{} {{
@@ -103,6 +117,12 @@ peripheral_handlers = {
         'size': 0x6c,
         'buffer': lambda: configuration.mem_regions['ethmac'],
         'config_entry': 'ETH_LITEETH'
+    },
+    'i2c0' : {
+        'handler': i2c_handler,
+        'reference': 'i2c0',
+        'size': 0x4,
+        'config_entry': 'I2C_LITEX'
     }
 }
 

--- a/generate-zephyr-dts.py
+++ b/generate-zephyr-dts.py
@@ -150,7 +150,7 @@ def generate_config():
     result = ""
     for name, handler in peripheral_handlers.items():
         if name not in configuration.peripherals.keys():
-            result += "-DCONFIG_{}=n".format(handler['config_entry'])
+            result += "-DCONFIG_{}=n ".format(handler['config_entry'])
     return result
 
 


### PR DESCRIPTION
This PR adds generation of the LiteX I2C controller entries in DT for Zephyr and Renode's repl.