### PR TITLE
allow "imac" cpu variant

### DIFF
--- a/generate-renode-scripts.py
+++ b/generate-renode-scripts.py
@@ -210,6 +210,10 @@ cpu: CPU.VexRiscv @ sysbus
     cpuType: "rv32ima"
     privilegeArchitecture: PrivilegeArchitecture.Priv1_10
 """
+        elif variant in ["i", "im", "ima", "imac"]:
+            result += """
+    cpuType: "rv32{}"
+""".format(variant)
         else:
             result += """
     cpuType: "rv32im"


### PR DESCRIPTION
I do most my tests with cpu-variant=imac+debug. This makes it possible to run the baremetal demo also in Renode with this CPU variant.