### PR TITLE
Git: Ignore pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/litex/__pycache__


### PR DESCRIPTION
After running the generator scripts, there are some pycache artifacts, which should not become part of the git repository. So we gitignore them.