### PR TITLE
generate-zephyr-dts.py: refactored version V2

### DIFF
--- a/generate-zephyr-dts.py
+++ b/generate-zephyr-dts.py
@@ -12,7 +12,9 @@
 # - 2021-07-05 Henk Vergonet <henk.vergonet@gmail.com>
 #    removed dependency on intermediate interpretation layers
 #    switch to JSON csr
-#    fix uart size parameter
+# - 2021-07-15 Henk Vergonet <henk.vergonet@gmail.com>
+#    added identifier_mem handler as dna0
+#    added spiflash as spi0
 #
 
 import argparse
@@ -87,6 +89,12 @@ overlay_handlers = {
         'size': 0x80,
         'config_entry': 'ETH_LITEETH'
     },
+    'spiflash': {
+        'handler': peripheral_handler,
+        'alias': 'spi0',
+        'size': 12,
+        'config_entry': 'SPI_LITESPI'
+    },
     'i2c0' : {
         'handler': i2c_handler,
         'size': 0x4,
@@ -95,6 +103,11 @@ overlay_handlers = {
     'main_ram': {
         'handler': ram_handler,
         'alias': 'ram0',
+    },
+    'identifier_mem': {
+        'handler': peripheral_handler,
+        'alias': 'dna0',
+        'size': 0x100,
     },
 }
 

--- a/generate-zephyr-dts.py
+++ b/generate-zephyr-dts.py
@@ -12,6 +12,7 @@
 # - 2021-07-05 Henk Vergonet <henk.vergonet@gmail.com>
 #    removed dependency on intermediate interpretation layers
 #    switch to JSON csr
+#    fix uart size parameter
 # - 2021-07-15 Henk Vergonet <henk.vergonet@gmail.com>
 #    added identifier_mem handler as dna0
 #    added spiflash as spi0


### PR DESCRIPTION
In reference to:[https://github.com/litex-hub/litex-renode/pull/34](https://github.com/litex-hub/litex-renode/pull/34)

The changes are part of an effort to enable platformio to handle the
different litex-board variants for the zephyr framework.
The resulting changes are aimed for better maintainability.

 -  Removed the dependency on the intermediate interpretations from
    the configuration class. No external python modules required.
    Less code with similar output results.
 -  Switched to JSON as it is better in preserving structure than CSV
    format.
 -  Refactored the formatting and translation handlers.
 -  changed uart io size parameter to 0x20, to include last uart address:
    uart_rxfull = CSR_BASE + 0x1c

Example session:

$ generate-zephyr-dts.py --dts - --config - src/board.csr.json
Generating overlay for: uart
Generating overlay for: timer0
Generating overlay for: ethmac
Generating overlay for: i2c0
  dtsi key 'i2c0' not found, disable i2c0
Generating overlay for: main_ram
No overlay handler for: ctrl at 0xf0000000
No overlay handler for: ethphy at 0xf0001000
No overlay handler for: identifier_mem at 0xf0001800
No overlay handler for: sdram at 0xf0002000
No overlay handler for: spiflash at 0xf0002800

DST output:
===========
&uart0 {
    reg = <0xf0003800 0x20>;
    interrupts = <0x0 0>;
};
&timer0 {
    reg = <0xf0003000 0x40>;
    interrupts = <0x1 0>;
};
&eth0 {
    reg = <0xf0000800 0x80 0x80000000 0x2000>;
    interrupts = <0x2 0>;
};
&i2c0 {
    status = "disabled";
};
&ram0 {
    reg = <0x40000000 0x400000>;
};

Config output:
==============
 -DCONFIG_UART_LITEUART=y -DCONFIG_LITEX_TIMER=y -DCONFIG_ETH_LITEETH=y -DCONFIG_I2C_LITEX=n

Signed-off-by: Henk Vergonet <henk.vergonet@gmail.com>